### PR TITLE
Update strelka_pipeline and realignment_pipeline

### DIFF
--- a/realignment_pipeline/launch_genesis.sh
+++ b/realignment_pipeline/launch_genesis.sh
@@ -10,5 +10,4 @@ COMPONENT_VERSION="8.0"
 --num_pipelines 10 \
 -j 20 \
 -p /extscratch/morinlab/software/anaconda/2.3.0/envs/kronos-2.0.4/bin/python2.7 \
---qsub_options ' -pe ncpus {num_cpus} -l mem_free={mem} -l mem_token={mem} -l h_vmem={mem} -w n -S /bin/sh' \
---no_prefix
+--qsub_options ' -pe ncpus {num_cpus} -l mem_free={mem} -l mem_token={mem} -l h_vmem={mem} -w n -S /bin/sh'

--- a/realignment_pipeline/setup.GRCh38_no_alt.genesis.tsv
+++ b/realignment_pipeline/setup.GRCh38_no_alt.genesis.tsv
@@ -4,7 +4,7 @@ __GENERAL__	samtools	/extscratch/morinlab/software/samtools/1.2/bin/samtools
 __GENERAL__	bamhash_checksum_bam	LD_LIBRARY_PATH=/gsc/software/linux-x86_64-centos5/gcc-4.9.1/lib64/ /home/prasathp/repos/BamHash/bamhash_checksum_bam
 __GENERAL__	hash_read_names	/home/prasathp/repos/lab_scripts/hash_read_names/hash_read_names.py
 __GENERAL__	bwa	/extscratch/morinlab/software/bwa/0.7.6a/bin/bwa
-__GENERAL__	pysam_bam2fq	/home/prasathp/repos/lab_scripts/pysam_bam2fq/pysam_bam2fq.py
+__GENERAL__	pysam_bam2fq	/extscratch/morinlab/software/lab_scripts/11.2/pysam_bam2fq/pysam_bam2fq.py
 __GENERAL__	picard_binary	/extscratch/morinlab/software/picard_tools/1.136/picard.jar
 __GENERAL__	gatk_binary	/extscratch/morinlab/software/gatk/3.4-0/GenomeAnalysisTK.jar
 __GENERAL__	java_binary	/gsc/software/linux-x86_64-centos5/java-1.7.0-u13/bin/java

--- a/strelka_pipeline/README.md
+++ b/strelka_pipeline/README.md
@@ -3,7 +3,7 @@
 ## Notes
 
 1. This pipeline includes the bamUtil clipOverlap processing step by default. 
-Edit it accordingly if you do not need this step. 
+Edit it accordingly if you do not need this step. See also 3.
 
 2. Note that you should update the `strelka_config` option in the setup file 
 according to whether your samples are genomes or not. 
@@ -17,3 +17,5 @@ Here are handy configs on Genesis:
 	# For anything else (exomes, targeted) 
 	/extscratch/morinlab/software/strelka_workflow/1.0.14/etc/strelka_config_bwa_exome.ini
 	```
+
+3. If you are running this pipeline on BAM files generated from the Morin Lab realignment pipeline, they have already been processed with clipOverlap and indexed. You should update the `--config-file` in `launch.sh` to use the `tasks_post_realignment_pipeline.yaml` file which omits these steps.

--- a/strelka_pipeline/tasks_post_realignment_pipeline.yaml
+++ b/strelka_pipeline/tasks_post_realignment_pipeline.yaml
@@ -1,0 +1,99 @@
+__TASK_STRELKA__:
+    reserved:
+        # do not change this section.
+        component_name: 'strelka'
+        component_version: 'v1.0.0'
+        seed_version: 'v1.0.14'
+    run:
+        # NOTE: component cannot run in parallel mode.
+        use_cluster: True
+        memory: '1G'
+        num_cpus: 12
+        forced_dependencies:
+        add_breakpoint: False
+        env_vars:
+        boilerplate: ("__SHARED__", "setup_env")
+    component:
+        input_files:
+            reference: ("__SHARED__", "reference")
+            normal_bam: ("__SAMPLES__", "normal_bam")
+            tumour_bam: ("__SAMPLES__", "tumour_bam")
+            config_file: ("__SHARED__", "strelka_config")
+        output_files:
+            passed_snvs_vcf: "1-strelka/$sample_id.strelka_passed_snvs.vcf"
+            output_dir: "1-strelka/strelka_output"
+            passed_indels_vcf: "1-strelka/$sample_id.strelka_passed_indels.vcf"
+        parameters:
+            num_threads: 12
+
+
+__TASK_VCF2MAF_SNVS__:
+    reserved:
+        # do not change this section.
+        component_name: 'vcf2maf_1_6_2'
+        component_version: 'v1.0.0'
+        seed_version: '1.6.2'
+    run:
+        # NOTE: component cannot run in parallel mode.
+        use_cluster: True
+        memory: ("__SHARED__", "vep_mem")
+        num_cpus: ("__SHARED__", "vep_threads")
+        forced_dependencies: []
+        add_breakpoint: False
+        env_vars:
+        boilerplate: ("__SHARED__", "setup_env")
+    component:
+        input_files:
+            vep_data: ("__SHARED__", "vep_data_dir")
+            custom_enst: '__OPTIONAL__'
+            ref_fasta: ("__SHARED__", "reference")
+            input_vcf: ("__TASK_STRELKA__", "passed_snvs_vcf")
+            vep_path: ("__SHARED__", "vep_path")
+        output_files:
+            output_maf: "2-vcf2maf/$sample_id.snvs.passed.maf"
+        parameters:
+            min_hom_vaf: '__OPTIONAL__'
+            ncbi_build: ("__SHARED__", "vep_ncbi_build")
+            maf_center: '__OPTIONAL__'
+            vcf_tumor_id: 'TUMOR'
+            vep_forks: ("__SHARED__", "vep_threads")
+            tumor_id: ("__SAMPLES__", "tumour_id")
+            normal_id: ("__SAMPLES__", "normal_id")
+            species: ("__SHARED__", "vep_species")
+            vcf_normal_id: 'NORMAL'
+
+
+__TASK_VCF2MAF_INDELS__:
+    reserved:
+        # do not change this section.
+        component_name: 'vcf2maf_1_6_2'
+        component_version: 'v1.0.0'
+        seed_version: '1.6.2'
+    run:
+        # NOTE: component cannot run in parallel mode.
+        use_cluster: True
+        memory: ("__SHARED__", "vep_mem")
+        num_cpus: ("__SHARED__", "vep_threads")
+        forced_dependencies: ["__TASK_VCF2MAF_SNVS__"]
+        add_breakpoint: False
+        env_vars:
+        boilerplate: ("__SHARED__", "setup_env")
+    component:
+        input_files:
+            vep_data: ("__SHARED__", "vep_data_dir")
+            custom_enst: '__OPTIONAL__'
+            ref_fasta: ("__SHARED__", "reference")
+            input_vcf: ("__TASK_STRELKA__", "passed_indels_vcf")
+            vep_path: ("__SHARED__", "vep_path")
+        output_files:
+            output_maf: "2-vcf2maf/$sample_id.indels.passed.maf"
+        parameters:
+            min_hom_vaf: '__OPTIONAL__'
+            ncbi_build: ("__SHARED__", "vep_ncbi_build")
+            maf_center: '__OPTIONAL__'
+            vcf_tumor_id: 'TUMOR'
+            vep_forks: ("__SHARED__", "vep_threads")
+            tumor_id: ("__SAMPLES__", "tumour_id")
+            normal_id: ("__SAMPLES__", "normal_id")
+            species: ("__SHARED__", "vep_species")
+            vcf_normal_id: 'NORMAL'

--- a/strelka_pipeline/tasks_post_realignment_pipeline.yaml
+++ b/strelka_pipeline/tasks_post_realignment_pipeline.yaml
@@ -9,7 +9,7 @@ __TASK_STRELKA__:
         use_cluster: True
         memory: '1G'
         num_cpus: 12
-        forced_dependencies:
+        forced_dependencies: []
         add_breakpoint: False
         env_vars:
         boilerplate: ("__SHARED__", "setup_env")


### PR DESCRIPTION
**Strelka**: Add YAML tasks file which omits those not needed for realignment pipeline output (`bamutil clipOverlap`, `samtools index`)
**Realignment**: Remove `--no-prefix` option due to bug in Kronos parallelization
